### PR TITLE
Add MIPI OSS policy compliance scaffolding

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,65 @@
+# Contributor License Agreement (CLA)
+
+Thank you for your interest in contributing to this MIPI Alliance Open Source
+Software (OSS) project (the "Project").
+
+This Contributor License Agreement ("Agreement") documents the rights granted by
+contributors to MIPI Alliance, Inc. ("MIPI"). By signing this Agreement — including
+by submitting a pull request and confirming your acceptance as instructed by the CLA
+Assistant bot — you accept and agree to the following terms for Your present and
+future Contributions submitted to the Project.
+
+## 1. Definitions
+
+- **"You"** (or **"Your"**) means the individual or legal entity that submits a
+  Contribution to the Project and that signs this Agreement.
+- **"Contribution"** means any original work of authorship, including any
+  modifications or additions to existing work, that is intentionally submitted by You
+  to the Project for inclusion in, or documentation of, the software maintained by the
+  Project.
+- **"Submit"** means any form of electronic, verbal, or written communication sent to
+  the Project, including but not limited to pull requests, issues, and comments.
+
+## 2. Representation of Authority
+
+You represent that:
+
+1. You are legally entitled to grant the licenses below.
+2. Each of Your Contributions is either Your original creation, or You have the right
+   to submit it under the license in Section 3.
+3. If Your employer or any other entity has rights to intellectual property that You
+   create that includes Your Contributions, You represent that **You have the right to
+   grant the licenses below on behalf of that entity**, that such entity has waived
+   such rights for Your Contributions to the Project, or that such entity has
+   otherwise authorized You to submit the Contributions on its behalf.
+
+## 3. License Grant
+
+You grant Your Contributions to the Project under the **BSD 3-Clause License** — the
+same license under which the Project is distributed (see
+[LICENSE.md](../LICENSE.md)). You agree that Your Contributions are provided inbound
+under that license, with no additional or different legal terms or conditions.
+
+## 4. No Warranty
+
+Unless required by applicable law or agreed to in writing, You provide Your
+Contributions on an **"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND**,
+either express or implied, including, without limitation, any warranties or
+conditions of title, non-infringement, merchantability, or fitness for a particular
+purpose.
+
+## 5. Notification
+
+You agree to notify the Project of any facts or circumstances of which You become
+aware that would make the representations in this Agreement inaccurate in any
+respect.
+
+## How to Sign
+
+When you open a pull request, the CLA Assistant will post instructions. To sign this
+Agreement, add a pull request comment with exactly the following text:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your signature (GitHub username and the signed pull request) is recorded by the CLA
+Assistant for the Project.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing
+
+Thank you for your interest in contributing to this MIPI Alliance Open Source
+Software (OSS) project. Contributions are governed by the *MIPI Policy and
+Procedures for Software Development Projects* and the project [governance
+model](../GOVERNANCE.md) (based on Annex D of that policy).
+
+## License of Contributions
+
+This project is licensed under the **BSD 3-Clause License** (see
+[LICENSE.md](../LICENSE.md)). All contributions are accepted **inbound under the
+same license** as the project's outbound license. By contributing, you agree that
+your contribution is licensed to MIPI under the BSD 3-Clause License.
+
+Contributions that attempt to attach **additional legal terms** to the contributed
+code will be rejected; the Maintainer may ask you to resubmit without those terms.
+
+## Contributor License Agreement (CLA)
+
+- **MIPI Member companies** may contribute to this project under the project's
+  license as described above.
+- **Non-members** are welcome to contribute to this public project, but must sign
+  the project [Contributor License Agreement](CLA.md) before a contribution can be
+  merged. This is enforced automatically on pull requests by the CLA Assistant.
+
+When you open a pull request, the CLA Assistant bot will post instructions. To sign,
+comment on the pull request with:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+## How to Contribute
+
+1. **Open an issue** to discuss substantial changes before investing significant
+   effort, using one of the issue templates.
+2. **Fork** the repository and create a topic branch for your change.
+3. Make your change with clear, focused commits and keep the code reviewable.
+4. Add or update tests where applicable (see the `test/` directory) and ensure the
+   existing test suite passes.
+5. **Open a pull request** against `main` and complete the pull request checklist.
+
+## Review and Merge
+
+- Pull requests targeting `main` require at least **one approving review** and may
+  not be merged by force-push or with unresolved required conversations.
+- Reviewers do not review their own work; the pull request author cannot approve
+  their own pull request.
+- Once approved and all checks (including the CLA check) pass, a Maintainer will
+  merge the change. The source branch is deleted automatically on merge.
+
+## Reporting Security Issues
+
+Please do **not** file security vulnerabilities as public issues. Follow the process
+in [SECURITY.md](SECURITY.md) instead.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a problem with the visualizer
+title: "[Bug] "
+labels: bug
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Input file / configuration used (attach the `.csv` if possible)
+2. Command or action taken
+3. ...
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include error messages, stack traces, or screenshots.
+
+## Environment
+
+- OS:
+- Python version:
+- Project version / commit:
+
+## Additional Context
+
+Anything else that may help diagnose the issue.
+
+<!-- Do NOT report security vulnerabilities here. See SECURITY.md. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/MIPI-Alliance/mipi-soundwire-I3S-visualizer/security/policy
+    about: Please report security vulnerabilities privately per SECURITY.md, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an enhancement or new capability
+title: "[Feature] "
+labels: enhancement
+---
+
+## Problem / Motivation
+
+What problem would this feature solve? What is the use case?
+
+## Proposed Solution
+
+A clear and concise description of what you would like to happen.
+
+## Alternatives Considered
+
+Any alternative solutions or features you have considered.
+
+## Additional Context
+
+Add any other context, references, or screenshots here.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+This project is a MIPI Alliance Open Source Software (OSS) project and follows the
+security process defined in the *MIPI Policy and Procedures for Software Development
+Projects* (Annex D.6).
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, report potential security issues by email to:
+
+- **software-security@mipi.org**
+
+Your report may optionally include a patch that fixes the identified issue.
+
+## What to Include
+
+To help us evaluate and triage the report quickly, please include where possible:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, or a proof of concept.
+- Affected version(s), tag(s), or commit(s).
+- Any known mitigations or workarounds.
+
+## Our Process
+
+The project Security Team (or, if none is designated, the project Maintainer) will:
+
+1. Evaluate each report and determine its seriousness, taking the project's known
+   uses into account.
+2. Where warranted, prepare a fix in a timely manner and coordinate disclosure.
+3. Notify the security contacts of any known external projects that incorporate
+   portions of this software before public disclosure, where appropriate.
+
+No information about a given security issue will be released publicly before the
+corresponding coordinated security release, except in zero-day situations where the
+vulnerability is already publicly known.
+
+Security releases are tagged using the form `major.minor.subminor-securityX`
+(for example, `1.2.3-security1`).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+<!--
+Thanks for your contribution! Please complete the checklist below.
+Non-members: the CLA Assistant bot will guide you through signing the CLA.
+-->
+
+## Description
+
+<!-- What does this pull request change, and why? -->
+
+## Related Issue(s)
+
+<!-- e.g. Closes #123 -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor / maintenance
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines.
+- [ ] My contribution is licensed under the project's **BSD 3-Clause License** with
+      no additional legal terms.
+- [ ] If I am a non-member, I have signed the [CLA](CLA.md) (the bot will prompt me).
+- [ ] I have added or updated tests where applicable, and the test suite passes.
+- [ ] I have updated documentation where applicable.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,37 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# The repository default workflow token is read-only; this job explicitly
+# requests the write scopes the CLA Assistant needs to record signatures and
+# update the PR status. No other workflow is affected.
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # Pinned to a full commit SHA for supply-chain security.
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/MIPI-Alliance/mipi-soundwire-I3S-visualizer/blob/main/.github/CLA.md'
+          # Signatures are stored on a dedicated, non-protected branch so the
+          # commit does not conflict with the "Protect Main" ruleset on main.
+          branch: 'cla-signatures'
+          allowlist: dependabot[bot],*[bot]
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-notsigned-prcomment: 'Thank you for your contribution. Before we can merge this pull request, all contributors must sign our Contributor License Agreement (CLA). Please read the [CLA Document](https://github.com/MIPI-Alliance/mipi-soundwire-I3S-visualizer/blob/main/.github/CLA.md) and sign it by posting the comment below.'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. Thank you!'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*	@roderickhogan @cirrus-jon @NielWarren
+# The @MIPI-Alliance/oss-maintainers team lets org admins approve PRs across
+# MIPI OSS projects; the named maintainers remain default owners as well.
+*	@roderickhogan @cirrus-jon @NielWarren @MIPI-Alliance/oss-maintainers
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,5 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*	@roderickhogan @lauranixon @plbossart
+*	@roderickhogan @cirrus-jon @NielWarren
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,70 @@
+# Project Governance
+
+This project is a MIPI Alliance Open Source Software (OSS) project. Its governance
+follows the Standard Governance Model in Annex D of the *MIPI Policy and Procedures
+for Software Development Projects*.
+
+## Project Roles
+
+### Maintainer
+The Maintainer is responsible for accepting contributions, managing branches, and
+making releases of the project. The Maintainer may also act as a Reviewer or a
+Developer. The current code owners are listed in [CODEOWNERS](CODEOWNERS).
+
+### Reviewer
+Reviewers review patches submitted by Developers before they are merged by the
+Maintainer. No Reviewer shall review their own work.
+
+### Developer
+Developers submit patches (via GitHub pull requests) with the intent of having them
+merged into the project repository. Developers may also act as Reviewers.
+
+## Accepting Contributions
+
+The Maintainer may accept contributions provided under the project's license
+(BSD 3-Clause). Contributions should be reviewed by one or more Reviewers before
+acceptance, and code should always be made reviewable before being merged.
+
+There is no difference in the acceptance process between contributions from MIPI
+Member companies and non-members, except that non-members must sign the project
+[CLA](.github/CLA.md). See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+
+## Managing Releases
+
+The Maintainer — or a member of the owning MIPI Working Group or the MIPI Software
+Working Group — may propose a new release. Releases are typically made when:
+
+1. Unreleased code fixes an important bug, or
+2. Unreleased code adds new functionality useful to project users (such
+   functionality should have smoketests that pass before release).
+
+Minor and sub-minor releases may be made at the Maintainer's discretion.
+
+## Version Numbering
+
+Version numbers consist of `major.minor.subminor` (for example, `1.0.0`).
+
+- **Major** releases are made for changes incompatible with previous interfaces.
+- **Minor** releases are made when new, important functionality is added.
+- **Sub-minor** releases are made for bug fixes or less-noteworthy additions.
+
+Backwards compatibility is maintained within a given major release.
+
+### Branching and Tags
+- New major and minor versions are tagged from `main`, creating a branch named
+  `vmajor.minor` at the same time. Sub-minor releases are tagged on that branch.
+- Each release has a tag named `branch.subminor`, where `subminor` starts at `0`.
+- For public releases, each release tag **shall be signed** by the Maintainer using
+  their own OpenPGP key. The Maintainer's key fingerprint should be conveyed
+  wherever the software is distributed.
+
+## Relationship to MIPI Specifications
+
+This project may be revised independently of any related MIPI specification. No
+dependency or relationship should be assumed between a code version and a
+specification version that happen to share the same number.
+
+## Security
+
+Security issues are handled per [SECURITY.md](.github/SECURITY.md) and Annex D.6 of
+the MIPI policy.


### PR DESCRIPTION
## Summary

Adds the repository scaffolding required to comply with the **MIPI Policy and
Procedures for Software Development Projects** (Annex D — Standard Governance Model)
and to raise the project's community-health coverage.

## Changes

- **CODEOWNERS** — update default owners to the current maintainers
  (`@roderickhogan @cirrus-jon @NielWarren`); remove inactive owners.
- **GOVERNANCE.md** — project roles (Maintainer / Reviewer / Developer), contribution
  acceptance, release management, version/branch/tag scheme, and signed releases.
- **.github/SECURITY.md** — private vulnerability reporting to
  `software-security@mipi.org` with coordinated disclosure (Annex D.6).
- **.github/CONTRIBUTING.md** — contribution workflow, inbound BSD-3-Clause licensing,
  member vs. non-member contributions, and the CLA requirement.
- **.github/CLA.md** — Contributor License Agreement (authority to grant + BSD-3-Clause
  grant) per policy 4.1.4.2.
- **.github/workflows/cla.yml** — CLA Assistant automation, pinned to a full commit SHA
  (`contributor-assistant/github-action` v2.6.1) with an explicit least-privilege
  `permissions:` block; signatures stored on a dedicated `cla-signatures` branch so they
  do not conflict with the Protect Main ruleset.
- **.github/pull_request_template.md** and **.github/ISSUE_TEMPLATE/** — PR checklist,
  bug-report and feature-request templates, and a config that routes security reports
  privately.

## Related repository settings (already applied)

- Default workflow token set to read-only; Actions cannot approve PRs.
- Secret scanning + push protection enabled; Dependabot security updates enabled.
- `delete_branch_on_merge` enabled.
- "Protect Main" ruleset now requires **code-owner review**.

## Notes for reviewers

- The CLA Assistant runs from the **base branch**, so it will begin enforcing on PRs
  only after this change is merged to `main`; it does not gate this PR.
- A repository **rename to lowercase** (`mipi-soundwire-i3s-visualizer`, policy 5.2.4)
  was intentionally deferred and is **not** part of this PR.
